### PR TITLE
Hopefully future-proofing and opacity shenanigans

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import HomePage from './pages/HomePage';
 import JournalPage from './pages/JournalPage';
@@ -7,20 +7,22 @@ import WormPage from './pages/WormPage';
 import DotMatrix from './components/DotMatrix';
 
 function App() {
+  const [isTappable, setIsTappable] = useState(false);
+
   return (
     <Router>
-        <div className="relative min-h-screen bg-black">
-          <DotMatrix isTappable={false} />
-          <div className="relative z-10">
-            <Routes>
-              <Route path="/" element={<HomePage />} />
-              <Route path="/root" element={<RootPage />} />
-              <Route path="/worm" element={<WormPage />} />
-              <Route path="/journal" element={<JournalPage />} />
-            </Routes>
-          </div>
+      <div className="relative min-h-screen bg-black">
+        <DotMatrix isTappable={isTappable} />
+        <div className="relative z-10">
+          <Routes>
+            <Route path="/" element={<HomePage />} />
+            <Route path="/root" element={<RootPage setIsTappable={setIsTappable} />} />
+            <Route path="/worm" element={<WormPage />} />
+            <Route path="/journal" element={<JournalPage />} />
+          </Routes>
         </div>
-      </Router>
+      </div>
+    </Router>
   );
 }
 

--- a/src/components/DotMatrix.tsx
+++ b/src/components/DotMatrix.tsx
@@ -72,7 +72,7 @@ const DotMatrix: React.FC<DotMatrixProps> = ({ isTappable }) => {
   };
 
   return (
-    <div className={`fixed inset-0 z-0 ${isTappable ? 'pointer-events-auto' : 'pointer-events-none'} flex items-center justify-center mt-20`}>
+    <div className={`fixed inset-0 z-0 ${isTappable ? 'pointer-events-auto' : 'pointer-events-none'} flex items-center justify-center`}>
       <div className="grid grid-cols-6 gap-2">
         {grid.flat().map((noteWithOctave, index) => (
           <div
@@ -82,7 +82,7 @@ const DotMatrix: React.FC<DotMatrixProps> = ({ isTappable }) => {
               noteWithOctave
                 ? (activeNote === noteWithOctave 
                     ? 'bg-green-500 opacity-100 scale-110' 
-                    : `bg-gray-300 ${isTappable ? 'opacity-50 hover:opacity-75 hover:scale-105' : 'opacity-25'}`)
+                    : `bg-gray-300 ${isTappable ? 'opacity-25 hover:opacity-75 hover:scale-105' : 'opacity-25'}`)
                 : 'bg-transparent'
             } ${isTappable ? 'cursor-pointer' : ''}`}
           />

--- a/src/components/TypewriterEffect.tsx
+++ b/src/components/TypewriterEffect.tsx
@@ -1,15 +1,21 @@
 import React, { useState, useEffect } from "react";
 
+interface SpecialWord {
+  word: string;
+  className: string;
+  onClick: (word: string) => void;
+}
+
 interface TypewriterEffectProps {
   text: string;
   loop?: boolean;
-  onWordClick?: (word: string) => void;
+  specialWords?: SpecialWord[];
 }
 
 const TypewriterEffect: React.FC<TypewriterEffectProps> = ({
   text,
   loop = false,
-  onWordClick
+  specialWords = [],
 }) => {
   const [displayText, setDisplayText] = useState("");
   const [index, setIndex] = useState(0);
@@ -38,11 +44,20 @@ const TypewriterEffect: React.FC<TypewriterEffectProps> = ({
     }
   }, [index, text.length, loop]);
 
-  // Handle word click
-  const handleWordClick = (word: string) => {
-    if (onWordClick) {
-      onWordClick(word);
+  const renderWord = (word: string, key: number) => {
+    const specialWord = specialWords.find(sw => sw.word.toLowerCase() === word.toLowerCase());
+    if (specialWord) {
+      return (
+        <span 
+          key={key}
+          onClick={() => specialWord.onClick(word)}
+          className={`cursor-pointer ${specialWord.className}`}
+        >
+          {word}
+        </span>
+      );
     }
+    return <span key={key}>{word}</span>;
   };
 
   return (
@@ -55,17 +70,10 @@ const TypewriterEffect: React.FC<TypewriterEffectProps> = ({
         const word = trimmedPart.replace(/[.,!?;:]$/, '');
         const punctuation = trimmedPart.slice(word.length);
         return (
-          <span key={index}>
-            <span 
-              onClick={() => handleWordClick(word)}
-              className={`${
-                word.toLowerCase() === 'scales' ? 'cursor-pointer transition-colors duration-200 text-green-500' : ''
-              }`}
-            >
-              {word}
-            </span>
+          <React.Fragment key={index}>
+            {renderWord(word, index)}
             {punctuation}
-          </span>
+          </React.Fragment>
         );
       })}
       <span className="absolute w-2 h-5 bg-white ml-1 animate-blink"></span>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -12,7 +12,7 @@ const HomePage: React.FC = () => {
 
   return (
     <div className='min-h-screen flex flex-col justify-center items-center p-5 font-tiny5 text-white'>
-      <TypewriterEffect text="Are you the root or the worm?" />
+      <TypewriterEffect text="are you the root or the worm?" />
       <div className="mt-8 space-x-4">
         <button
           className="border border-white px-5 py-2 hover:bg-white hover:text-black transition-colors duration-200"

--- a/src/pages/RootPage.tsx
+++ b/src/pages/RootPage.tsx
@@ -1,8 +1,11 @@
 import React, { useState } from "react";
 import TypewriterEffect from "../components/TypewriterEffect";
-import DotMatrix from "../components/DotMatrix";
 
-const RootPage: React.FC = () => {
+interface RootPageProps {
+  setIsTappable: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const RootPage: React.FC<RootPageProps> = ({ setIsTappable }) => {
   const [showDotMatrix, setShowDotMatrix] = useState(false);
   const sentence =
     "four weeks ago in flagstaff i met a man who considered himself a dragon and so displayed scales, each laden with a poultice created with solved forms of extra-intrinsical abolishment. deeply concerned for the man's wellbeing i produced a blindfold from the inner pocket of my best jacket and wrestled him to the ground.";
@@ -11,26 +14,28 @@ const RootPage: React.FC = () => {
     {
       word: "scales",
       className: "transition-colors duration-200 text-green-500",
-      onClick: () => setShowDotMatrix(true)
+      onClick: () => {
+        setIsTappable(true);
+        setShowDotMatrix(true);
+      }
     }
   ];
 
   const handleCloseDotMatrix = () => {
+    setIsTappable(false);
     setShowDotMatrix(false);
   };
 
   return (
     <>
-      <DotMatrix isTappable={showDotMatrix} />
-      {showDotMatrix && (
+      {showDotMatrix ? (
         <button 
           onClick={handleCloseDotMatrix}
           className="absolute top-4 right-4 text-white bg-red-500 px-4 py-2 rounded"
         >
           Close
         </button>
-      )}
-      {!showDotMatrix && (
+      ) : (
         <div className="min-h-screen flex flex-col justify-center items-center p-5 text-white">
           <div className="w-full max-w-2xl">
             <TypewriterEffect 

--- a/src/pages/RootPage.tsx
+++ b/src/pages/RootPage.tsx
@@ -7,11 +7,13 @@ const RootPage: React.FC = () => {
   const sentence =
     "four weeks ago in flagstaff i met a man who considered himself a dragon and so displayed scales, each laden with a poultice created with solved forms of extra-intrinsical abolishment. deeply concerned for the man's wellbeing i produced a blindfold from the inner pocket of my best jacket and wrestled him to the ground.";
 
-  const handleClick = (word: string) => {
-    if (word.toLowerCase() === 'scales') {
-      setShowDotMatrix(true);
+  const specialWords = [
+    {
+      word: "scales",
+      className: "transition-colors duration-200 text-green-500",
+      onClick: () => setShowDotMatrix(true)
     }
-  };
+  ];
 
   const handleCloseDotMatrix = () => {
     setShowDotMatrix(false);
@@ -33,8 +35,8 @@ const RootPage: React.FC = () => {
           <div className="w-full max-w-2xl">
             <TypewriterEffect 
               text={sentence} 
-              loop={false} 
-              onWordClick={handleClick}
+              loop={true} 
+              specialWords={specialWords}
             />
           </div>
         </div>


### PR DESCRIPTION
# Changes to typewriter effect and dot matrix implementation

- Typewriter effect now accepts a word object that has the word in question and styling for said word for further implementation on different components down the line
- Dot matrix is now only rendered once eliminating the visual bug with opacity occurring before

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes